### PR TITLE
Reinstate C _scandir module and fix variable name.

### DIFF
--- a/_scandir.c
+++ b/_scandir.c
@@ -234,7 +234,7 @@ static PyObject *
 scandir_helper(PyObject *self, PyObject *args)
 {
     char *name = NULL;
-    PyObject *d, *v, *name_ino_type;
+    PyObject *d, *v, *name_type;
     DIR *dirp;
     struct dirent *ep;
     int arg_is_unicode = 1;

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,7 @@ setup(
                      "files in a directory, and also exposes the extra information most OSes provide "
                      "while iterating files in a directory. Read more at the GitHub project page.",
     py_modules=['scandir'],
-# TODO: reinstate C extension module
-#    ext_modules=[Extension('_scandir', ['_scandir.c'])],
+    ext_modules=[Extension('_scandir', ['_scandir.c'])],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Hi Ben,

I do not know if it was your intention to keep the _scandir module disabled or not. It appears that 7176d19796a0ea723e9e35ad0d2ec6ddb24217e9 was meant to enable it.

I have attached two small changes to re-enable the module and make it compile on *nix platforms.

Please ignore this pull request if there is still work left to finish on the _scandir module.

Thanks
