### PR TITLE
Working fts implementation.

### DIFF
--- a/README.fts
+++ b/README.fts
@@ -1,0 +1,220 @@
+The `fts` library is a thin wrapper around the platform's `fts` function,
+which provides a different API from `os.walk` for walking the filesystem.
+
+Performance
+===========
+
+`fts` is designed to be fast; it's what the `find` command uses. If
+there are platform-/filesystem-specific opportunities to skip `stat`
+in some cases, your platform's implementation will know about then. If
+`chdir` or fd-relative (`*at`) functions can help, it'll use them.
+
+The fact that the API iterates each entry, instead of each directory's
+worth of entries, is both good and bad. On the one hand, it means
+you're yielding back from C to Python `X*Y` times, instead of just `X`
+times. On the other hand, you usually have to iterate those entry
+lists, so really you're replacing nested `X` and `Y` loops with that
+single `X*Y` loop. (And of course for huge directories, not building
+those big lists in the first place will help.)
+
+Rather than come up with my own benchmarks, I just used the one from
+`scandir`, adding an obvious `fts` test alongside the existing ones,
+and then testing it with various different wrapper implementations.
+
+Unfortunately, the only machines I have to test on have SSDs and OS X
+10.8-10.10 (which has pretty good caching), so take this all with a
+grain of salt.
+
+    os.walk : 0.077s
+	scandir : 0.044s -- 1.7x as fast
+	fts_bare: 0.013s -- 5.9x as fast
+    fts_cvt : 0.128s -- 0.6x as fast
+	fts_copy: 0.039s -- 2.0x as fast
+	fts_opt : 0.041s -- 1.8x as fast
+	fts_c   : 0.023s -- 3.3x as fast
+	
+`fts_bare` just gives you the native `FTSENT(Structure)` objects. To
+access the information, you have to get the `.value` or `.contents`
+all over the place, convert and decode strings stored as `c_char_p`
+and length, deal with file kinds as integers, etc. That's not friendly
+enough to actually use. But for a test that just ignores every entry
+(as this benchmark does), it works, so this gives us an upper
+limit. Which is pretty nice.
+
+`fts_cvt` converts all of that stuff to nice Python `Entry` objects
+with decode `str` strings, `enum` file kinds, etc. It's slower than
+`scandir`, and even `os.walk`.
+
+`fts_copy` is a quick test to see how much of that cost is inherent to
+converting each object in Python; it fakes the "conversion" by just
+creating a new Python object that has the `FTSENT` as a member. I
+tried with both `ctypes` and `cffi`, and with a `namedtuple` and a
+`__slots__` class, and this was the fastest, but they're all about the
+same. As you can see, the cost of doing any converting in Python is
+pretty high.
+
+`fts_opt` is the closest I could come to the upper limit of `fts_copy`
+in Python: It does the fast conversions immediately, the slow ones on
+demand, and the really slow ones on demand with caching.
+
+`fts_c` implements the `Entry` object, and the conversion from
+`FTSENT`, in Cython. It has a refcounting error, and it uses a nasty
+cheat (linking to code from `posixmodule.c` at runtime), and the code
+is a mess, but it demonstrates that a serious implementation will have
+to be in C, but that doing so is worth it. (That being said, it might
+be worth having the pure `cffi`-based version around as well, for
+PyPy. I'll have to test how well the native version works with
+cpyext.)
+
+Portability
+===========
+
+Not every platform has `fts`. In fact, it's basically just modern \*BSD
+(including OS X) and Linux.
+
+Many older \*nix systems have `nftw`, and there's an implementation of
+`fts` as a wrapper around `nftw`. For those that only have the
+`opendir` and `stat` families, the fallback code in the FreeBSD
+implementation of `fts` itself works almost out of the box. Of course
+you don't get any of the platform-specific optimizations that way, but
+you get some performance benefit, and you get the full `fts` API.
+
+Windows, and other non-\*nix systems, of course have nothing like
+`fts`. While Windows does provide a limited emulation of `opendir`,
+you wouldn't want to use it when you have `FindFirstFile`. And
+implementing `fts` on top of `FindFirstFile` looks like a non-trivial
+project.
+
+Also, `fts` was not standardized in the most recent POSIX, so the
+closest thing to a standard is what 4.4BSD provided. This doesn't
+include the `clientptr` and `stream` functions, doesn't guarantee to
+set `NOCHDIR` if it decides not to `chdir`, and means `children`
+doesn't have a reliable API. Fortunately, none of those things should
+be necessary, so I stuck with what's available in 4.4BSD.
+
+Like everything else filesystem-related, `fts` relies on a mess of
+platform-specific structures and typedefs--the same ones that Python
+already wraps up in `os`, `stat`, etc., but those wrappers aren't
+exposed to non-stdlib modules.
+
+`ctypes` does a horrible job with this. You need a `setup.py` that
+does a bunch of `autoconf`-like tests just to figure out all the right
+type. Without that, my initial implementation worked on OS X
+10.8-10.10 and nothing else...
+
+`cffi` can handle things a little better (see the included code), but
+it has its own negatives. Besides not being in the stdlib (except in
+PyPy), the default usage compiles the C code on first run rather than
+at setup time.
+
+`Cython` seemed like a good bet, but it turns out to be a big pain to
+create C-implemented but Python-accessible objects that hold onto
+references to C-private objects. Or maybe I'm just out of practice
+with `Cython`.
+
+I think the right answer will be to write it in C. Which isn't too
+terrible; I just haven't done it yet.
+
+API
+===
+
+The `fts` function was designed to make it easier to support a
+mostly-portable find command. It's powerful and flexible and
+simple in the way that C is simple (which doesn't necessarily mean
+friendly...), and they've thought of all kinds of edge cases, like
+cycles through alternating names and so on.
+
+The biggest difference between the fts API and the os.walk API is that
+fts iterates directory entries (giving you name, path, kind, and, if
+you want it, full stat info) while os.walk iterates subdirectories
+(giving you lists of names for files and directories).
+
+The downside is that a different API is different. It's certainly not
+a drop-in replacement for `os.walk`. And, while you could write such a
+replacement, I haven't done it yet. And I'm not sure it's a great idea.
+
+To compare the APIs, here are a couple of examples:
+
+    def size_fts(path):
+        with fts.FTS(path) as f:
+            return sum(entry.stat.st_size for entry in f
+                       if entry.info == fts.Info.F)
+
+    def size_walk(path):
+        sum(os.path.getsize(os.path.join(root, name))
+            for root, dirs, files in os.walk(path)
+            for name in files)
+
+    def all_non_hidden_fts(path):
+        with fts.FTS(path) as f:
+            for entry in f:
+                if entry.name.startswith('.'):
+                    fts.skip(entry)
+                elif entry.info == fts.Info.F:
+                    yield entry
+
+    def all_non_hidden_walk(path):
+        for root, dirs, files in os.walk(path):
+            dirs[:] = [dir for dir in dirs if not dir.startswith('.')]
+            yield from (os.path.join(root, file) for file in files
+                        if not file.startswith('.'))
+
+Unifying `fts` and `scandir`
+============================
+
+The ideal solution would be to come up with an API that allows for all
+of the common advantages of `fts` and `scandir`. And I don't think
+`os.walk` is that API. The very fact that the `--size` implementation
+with `scandir` didn't using `scandir.walk`, but instead a manual
+recursive implementation around `scandir.scandir`, is pretty good
+evidence that `os.walk` is not what you want.
+
+For comparison, here's what a native `fts` implementation of the two
+functions (do nothing vs. sum sizes) looks like:
+
+    with fts.FTS(path, options=fts.Option.NOSTAT) as f:
+	    for entry in f:
+		    pass
+
+    with fts.FTS(path) as f:
+        return sum(entry.stat.st_size for entry in f
+                   if entry.info == fts.Info.F)
+
+On the other hand, I think `fts` is pretty close to the right
+interface, it just needs to be made more Pythonic and stripped
+down. See the `ftss.py` file for an example of an interface that was
+pretty easy to implement on top of both `fts` and `scandir` that seems
+reasonably close. (It needs to be fleshed out, but the limitations are
+mostly caused by the way `scandir` works, which would be easy to
+change.)
+
+In particular, features of `fts` that aren't needed include:
+
+* No multiple roots.
+* Always follow a root symlink (eliminating the COMFOLLOW option).
+* Drop the `compar` sorting argument, and drop the guarantee that
+  entries will be provided in directory order.
+* Don't support any of the post-4.4BSD extensions.
+* Drop `children`.
+* Drop `path` and `name`; `accpath` is enough.
+* Drop `parent`, `link`, and `cycle`.
+* Pull out the special cases as separate values, instead of cramming
+  them into pseudo-filetypes. (This also means we can drop NOSTAT_TYPE.)
+* Change the filetypes from cryptic symbols like `F` and `DOT`
+  to `pathlib`-style methods.
+* The `Entry` object could be basically a `scandir.DirEntry` object,
+  with more methods added.
+* Or, even better, the `Entry` object could be a `pathlib.Path`
+  subclass. This might be a bit confusing; e.g., with `logical=False`,
+  should `is_file` be `False` for a symlink to a regular file, or
+  check on the fly, or raise? Also, some of this information is always
+  available for free with all of `fts`, `readdir`, and
+  `FindFirstFile`, while other things may require a syscall, depend on
+  both the options you chose and the platform you're on.
+* Drop `again`.
+* Drop `follow` in favor of an `lstat` method like `scandir`'s (which
+  calls `f.follow` and `next(f)` in the `fts` implementation).
+* The `skip` method doesn't need to take an `Entry` object (or it
+  could be a method on `Entry` rather than `FTS`); if you're not using
+  `children` or `stream` you can't skip anything but the current entry
+  anyway.

--- a/fts.py
+++ b/fts.py
@@ -1,0 +1,339 @@
+import collections
+from cffi import FFI
+from enum import IntEnum
+import os
+import sys
+
+__all__ = ['Options', 'Info', 'Entry', 'FTS']
+
+def _cmp(x, y):
+    if x < y:
+        return -1
+    elif y < x:
+        return 1
+    else:
+        return 0
+
+def key_to_cmp(key, reverse=False):
+    if key:
+        if reverse:
+            def cmp(x, y):
+                return _cmp(key(y), key(x))
+        else:
+            def cmp(x, y):
+                return _cmp(key(x), key(y))
+    else:
+        if reverse:
+            def cmp(x, y):
+                return _cmp(y, x)
+        else:
+            def cmp(x, y):
+                return _cmp(x, y)
+    return cmp
+
+class Options(IntEnum):
+    COMFOLLOW   = 0x001 # follow command line symlinks
+    LOGICAL     = 0x002 # logical walk
+    NOCHDIR     = 0x004 # don't change directories
+    NOSTAT      = 0x008 # don't get stat info
+    PHYSICAL    = 0x010 # physical walk
+    SEEDOT      = 0x020 # return dot and dot-dot
+    XDEV        = 0x040 # don't cross devices
+    WHITEOUT    = 0x080 # return whiteout information
+    COMFOLLOWDIR= 0x400 # (non-std) follow command line symlinks for directories only
+    OPTIONMASK  = 0x4ff # valid user option mask
+
+    NAMEONLY    = 0x100 # (private) child names only
+    STOP        = 0x200
+
+class SetOptions(IntEnum):
+    AGAIN       = 1
+    FOLLOW      = 2
+    NOINSTR     = 3
+    SKIP        = 4
+
+class Info(IntEnum):
+    D       =  1 # preorder directory
+    DC      =  2 # directory that causes cycles
+    DEFAULT =  3 # none of the above
+    DNR     =  4 # unreadable directory
+    DOT     =  5 # dot or dot-dot
+    DP      =  6 # postorder directory
+    ERR     =  7 # error; errno is set
+    F       =  8 # regular file
+    INIT    =  9 # initialized only
+    NS      = 10 # stat(2) failed
+    NSOK    = 11 # no stat(2) requested
+    SL      = 12 # symbolic link
+    SLNONE  = 13 # symbolic link without target
+    W       = 14 # whiteout object
+    def is_dir(self):
+        return self in (Info.D, Info.DC, Info.DNR, Info.DOT, Info.DP)
+    def is_file(self):
+        return self == Info.F
+    def is_symlink(self):
+        return self in (Info.SL, Info.SLNONE)
+    def is_error(self):
+        return self in (Info.DNR, Info.ERR, Info.NS)
+    def has_stat(self):
+        return self not in (Info.DNR, Info.ERR, Info.NS, Info.NSOK)
+
+def get_sizes():
+    types = ('dev_t', 'mode_t', 'nlink_t', 'ino_t', 'uid_t', 'gid_t',
+             'off_t', 'blkcnt_t', 'blksize_t', 'time_t')
+    ffi = FFI()
+    ffi.cdef(''.join('#define SIZE_OF_{} ...\n'.format(t) for t in types))
+    lib = ffi.verify('#include <sys/types.h>\n' +
+                     ''.join('#define SIZE_OF_{} sizeof({})\n'.format(t, t)
+                             for t in types))
+    return ''.join(
+        'typedef uint{}_t {};\n'.format(getattr(lib, 'SIZE_OF_'+t)*8, t)
+        for t in types)
+
+ffi = FFI()
+ffi.cdef(get_sizes() + """
+    typedef unsigned short u_short;
+    struct timespec {
+        time_t tv_sec;
+        long tv_nsec;
+        ...;
+    };
+    /* Note that POSIX does not require the timespec fields, or even mention
+       them beyond saying "The timespec structure may be defined as described
+       in <time.h>." However, both BSD (including OS X) and linux define them
+       like this. */
+    struct stat {
+        dev_t           st_dev;           /* ID of device containing file */
+        mode_t          st_mode;          /* Mode of file (see below) */
+        nlink_t         st_nlink;         /* Number of hard links */
+        ino_t           st_ino;           /* File serial number */
+        uid_t           st_uid;           /* User ID of the file */
+        gid_t           st_gid;           /* Group ID of the file */
+        dev_t           st_rdev;          /* Device ID */
+        struct timespec st_atimespec;     /* time of last access */
+        struct timespec st_mtimespec;     /* time of last data modification */
+        struct timespec st_ctimespec;     /* time of last status change */
+        struct timespec st_birthtimespec; /* time of file creation(birth) */
+        off_t           st_size;          /* file size, in bytes */
+        blkcnt_t        st_blocks;        /* blocks allocated for file */
+        blksize_t       st_blksize;       /* optimal blocksize for I/O */
+    };     
+
+    typedef ... FTS;
+     
+    typedef struct _ftsent {
+            u_short fts_info;               /* flags for FTSENT structure */
+            char *fts_accpath;              /* access path */
+            char *fts_path;                 /* root path */
+            u_short fts_pathlen;            /* strlen(fts_path) */
+            char fts_name[];                /* file name */
+            u_short fts_namelen;            /* strlen(fts_name) */
+            short fts_level;                /* depth (-1 to N) */
+            int fts_errno;                  /* file errno */
+            long fts_number;                /* local numeric value */
+            void *fts_pointer;              /* local address value */
+            struct ftsent *fts_parent;      /* parent directory */
+            struct ftsent *fts_link;        /* next file structure */
+            struct ftsent *fts_cycle;       /* cycle structure */
+            struct stat *fts_statp;         /* stat(2) information */
+            ...;
+    } FTSENT;
+
+    FTS *
+    fts_open(char * const *path_argv, int options,
+        int (*compar)(const FTSENT **, const FTSENT **));
+
+    FTSENT *
+    fts_read(FTS *ftsp);
+
+    FTSENT *
+    fts_children(FTS *ftsp, int options);
+
+    int
+    fts_set(FTS *ftsp, FTSENT *f, int options);
+
+    int
+    fts_close(FTS *ftsp);     
+""")
+
+libc = ffi.verify("""
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fts.h>
+""")
+
+def _make_error(*args, code=None):
+    if code is None:
+        code = ffi.errno
+    return OSError(code, os.strerror(code), *args)
+
+def _make_path(ent):
+    if isinstance(ent, Entry):
+        ent = ent.ftsent
+    if ent.fts_path:
+        return ffi.string(ent.fts_path).decode(sys.getfilesystemencoding())
+    else:
+        return ffi.string(ent.fts_name).decode(sys.getfilesystemencoding())
+
+class Entry:
+    __slots__ = ('ftsent', '_nostat', '_stat')
+    def __init__(self, ftsent, nostat=False):
+        self.ftsent = ftsent
+        self._nostat = nostat
+        self._stat = None
+    @property
+    def info(self):
+        return Info(self.ftsent.fts_info)
+    @staticmethod
+    def _stringify(s):
+        return ffi.string(s).decode(sys.getfilesystemencoding()) if s else '<NULL>'
+    @property
+    def accpath(self):
+        return self._stringify(self.ftsent.fts_accpath)
+    @property
+    def path(self):
+        return self._stringify(self.ftsent.fts_path)
+    @property
+    def name(self):
+        return self._stringify(self.ftsent.fts_name)
+    @property
+    def level(self):
+        return self.ftsent.fts_level
+    @property
+    def errno(self):
+        return self.ftsent.fts_errno
+    @property
+    def stat(self):
+        if self._nostat:
+            return None
+        if self._stat is None:
+            if not self.info.has_stat():
+                self._nostat = True
+                return None
+            def dts(ts):
+                return ts.tv_sec + ts.tv_nsec / 1000000000
+            def dtsns(ts):
+                return ts.tv_sec * 1000000000 + ts.tv_nsec
+            # Note: This works in CPython 3.4 on platforms that have all of
+            # the relevant fields (which includes BSD/OS X and Linux).
+            statp = self.ftsent.fts_statp
+            self._stat = os.stat_result((statp.st_mode, statp.st_ino, statp.st_dev,
+                                         statp.st_nlink, statp.st_uid, statp.st_gid,
+                                         statp.st_size,
+                                         dts(statp.st_atimespec),
+                                         dts(statp.st_mtimespec),
+                                         dts(statp.st_ctimespec),
+                                         int(dts(statp.st_atimespec)),
+                                         int(dts(statp.st_mtimespec)),
+                                         int(dts(statp.st_ctimespec)),
+                                         dtsns(statp.st_atimespec),
+                                         dtsns(statp.st_mtimespec),
+                                         dtsns(statp.st_ctimespec),
+                                         statp.st_blksize, statp.st_blocks,
+                                         0, 0, 0, # rdev, flags, gen
+                                         dts(statp.st_birthtimespec)))
+        return self._stat
+
+class FTS:
+    def __init__(self, *paths, options=None, key=None, reverse=False):
+        """FTS(path, options=None, key=None, reverse=False)
+
+        Begins an FTS traversal on the specified paths, iterating the
+        filesystem tree in depth-first order, yielding Entry structures.
+        Note that by default, unlike os.walk, directories are yielded twice,
+        both before and after their contents. (See Info for details.)
+
+        The paths can be either strings (in which case they're assumed to
+        be in the default file system encoding) or bytes.
+
+        The options are a bitmask of Options values, defaulting to
+        PHYSICAL if nothing is passed.
+        
+        If a key function is given, it will be called on pairs of Entry
+        structures; otherwise, the traversal order is the order of the
+        paths, and the native directory entry order within each path.
+        Note that accpath and path cannot be used (but name can), and
+        stat can only be used if stat was called (info is not NS or NSOK).         
+        The key objects only need to define <, and it is legal for two
+        objects to be incomparable (that is, not x<y and not y<x).
+
+        See your platform's fts(3) documentation for more details."""
+
+        self._fts = None
+        enc = sys.getfilesystemencoding()
+        def encpath(path):
+            try:
+                return path.encode(enc)
+            except AttributeError:
+                return path
+        def decpath(path):
+            try:
+                return path.decode(enc)
+            except AttributeError:
+                return path
+        path_cstrs = [ffi.new("char[]", encpath(path)) for path in paths]
+        path_cstrs.append(ffi.NULL)
+        path_argv = ffi.new("char *[]", path_cstrs)
+        self.paths = [decpath(path) for path in paths]
+        self.options = options
+        if options is None:
+            options = 0
+        if not options | Options.PHYSICAL | Options.LOGICAL:
+            options |= Options.PHYSICAL
+        if key:
+            compar = ffi.callback("int(FTSENT **, FTSENT**)",
+                                  key_to_cmp(key, reverse))
+        else:
+            compar = ffi.NULL
+        self._fts = libc.fts_open(path_argv, options, compar)
+        if not self._fts:
+            raise _make_error(':'.join(self.paths))
+    def close(self):
+        if self._fts:
+            libc.fts_close(self._fts)
+            self._fts = None
+    def __del__(self):
+        self.close()
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+    def __iter__(self):
+        return self
+    def __next__(self):
+        ent = libc.fts_read(self._fts)
+        if not ent:
+            if ffi.errno:
+                raise _make_error(':'.join(self.paths))
+            else:
+                raise StopIteration
+        return Entry(ent, self.options & Options.NOSTAT)
+    #def children(self):
+    #    ent = children(self._fts), walk the links and return a sequence
+    def set(self, entry, option):
+        if isinstance(entry, Entry):
+            entry = entry.ftsent
+        if libc.fts_set(self._fts, entry, option):
+            raise _make_error(_make_path(entry))
+    def again(self, ent):
+        self.set(ent, SetOptions.AGAIN)
+    def follow(self, ent):
+        self.set(ent, SetOptions.FOLLOW)
+    def skip(self, ent):
+        self.set(ent, SetOptions.SKIP)
+
+if __name__ == '__main__':
+    args = sys.argv[1:] if len(sys.argv) > 1 else '.'
+
+    with FTS(*args, options=Options.COMFOLLOW | Options.NOSTAT) as f:
+        for e in f:
+            #if e.info==Info.D and e.name.startswith('_'):
+            #    f.skip(e)
+            #elif e.info==Info.SL:
+            #    f.follow(e)
+            if e.info.is_error():
+                path = _make_error(_make_path(e), code=e.errno)
+            else:
+                path = e.path
+            print(e.info.name.ljust(7), e.level, path)

--- a/ftss.py
+++ b/ftss.py
@@ -1,0 +1,122 @@
+import copy
+import fts
+import os
+import pathlib
+import scandir
+import stat
+
+class ScandirDirEntry:
+    def __init__(self, entry):
+        self._entry = entry
+    @property
+    def name(self):
+        return self._entry.name
+    def lstat(self):
+        return self._entry.lstat()
+    def is_dir(self):
+        return self._entry.is_dir()
+    def is_file(self):
+        return self._entry.is_file()
+    def is_symlink(self):
+        return self._entry.is_symlink()
+    def __str__(self):
+        return str(self._entry)
+    __repr__ = __str__
+    
+def fts_scandir(path, *, logical=False, nochdir=False,
+                nostat=False, seedot=False, xdev=False,
+                _level=0):
+    for entry in scandir.scandir(path):
+        direntry = ScandirDirEntry(entry)
+        direntry.error = None
+        direntry.level = _level
+        direntry.postorder = False
+        direntry.skip = False
+        if not nostat:
+            try:
+                direntry.lstat()
+            except OSError as e:
+                direntry.error = e
+        if direntry.is_dir():
+            yield direntry
+            if not direntry.skip:
+                yield from fts_scandir(os.path.join(path, direntry.name),
+                                       logical=logical, nochdir=nochdir,
+                                       nostat=nostat, seedot=seedot, xdev=xdev,
+                                       _level=_level+1)
+            direntry = copy.copy(direntry)
+            direntry.postorder = True
+            yield direntry
+        else:
+            yield direntry
+
+class FtsDirEntry:
+    def __init__(self, entry):
+        self._entry = entry
+        self._path = pathlib.Path(entry.accpath)
+        self.skip = False
+    @property
+    def name(self):
+        return self._entry.accpath
+    @property
+    def level(self):
+        return self._entry.level
+    @property
+    def error(self):
+        return self._entry.error
+    @property
+    def postorder(self):
+        return self._entry.info == fts.Info.DP
+    def stat(self):
+        if self._entry.info.has_stat():
+            return self._entry.stat or self._path.stat()
+        return self._path.stat()
+    def lstat(self):
+        if self._entry.info == fts.Info.SL:
+            return self._entry.stat or self._path.lstat()
+        return self._path.lstat()
+    def is_dir(self):
+        if self._entry.info.is_dir():
+            return True
+        if self._entry.info != fts.Info.SL:
+            return False
+        return stat.ISDIR(self.lstat().st_mode)
+    def is_file(self):
+        if self._entry.is_file():
+            return True
+        if self._entry.info != fts.Info.SL:
+            return False
+        return stat.ISREG(self.lstat().st_mode)
+    def is_symlink(self):
+        return self._entry.is_symlink()
+    def __str__(self):
+        return '<{0}: {1!r}>'.format(self.__class__.__name__, self.name)
+    __repr__ = __str__
+            
+def fts_fts(path, *, logical=False, nochdir=False,
+            nostat=False, seedot=False, xdev=False):
+    options = fts.Options.COMFOLLOW
+    if logical: options |= fts.Options.LOGICAL
+    if nochdir: options |= fts.Options.NOCHDIR
+    if nostat: options |= fts.Options.NOSTAT
+    if seedot: options |= fts.Options.SEEDOT
+    if xdev: options |= fts.Options.XDEV
+    with fts.FTS(path, options=options) as f:
+        for entry in f:
+            direntry = FtsDirEntry(entry)
+            yield direntry
+            if direntry.skip:
+                f.skip(entry)
+
+if __name__ == '__main__':
+    import sys
+    args = sys.argv[1:] or ['.']
+    def test(f):
+        for entry in f:
+            if entry.name.startswith('_'):
+                entry.skip = True
+            print(entry.level, entry)            
+    for arg in args:
+        test(fts_scandir(arg))
+        test(fts_fts(arg))
+            


### PR DESCRIPTION
I'm not actually expecting this pull request to be accepted; look it over, comment on it, and reject it.

README.fts explains most of the details.

fts.py is a prototype wrapper around the `fts` function on linux and *BSD (including OS X) that provides a similar, but different, API to `os.walk`. It requires `cffi` (which a real implementation wouldn't—and a real implementation would probably be a lot faster, too, as discussed in the readme).

It does not include an `os.walk` replacement, just the `fts` interface. The updated benchmark.py shows how easy/hard it is to switch from `os.walk` to `fts.FTS`.

I've also includes an (incomplete) simplified-fts interface built on top of both `fts` and `scandir`, which you can see in ftss.py. I think something like this would be worth adding to the stdlib (maybe as `pathlib.Path.walk`?). I'm sure it has some bugs, on top of being incomplete; it's just to demonstrate the idea I raised in the readme.
