### PR TITLE
Fix bad placement of PyType_Ready call

### DIFF
--- a/_scandir.c
+++ b/_scandir.c
@@ -655,13 +655,13 @@ PyInit__scandir(void)
 void
 init_scandir(void)
 {
-    if (PyType_Ready(&FileIterator_Type) < 0) {
-        INITERROR;
-    }
-	
     PyObject *module = Py_InitModule("_scandir", scandir_methods);
 #endif
     if (module == NULL) {
+        INITERROR;
+    }
+
+    if (PyType_Ready(&FileIterator_Type) < 0) {
         INITERROR;
     }
 


### PR DESCRIPTION
PyType_Ready should be called for any PY_MAJOR_VERSION and MSVC didn't like the module var declaration not being at the top of the block.
