### PR TITLE
Issue #34: Free path data during path_cleanup

### DIFF
--- a/_scandir.c
+++ b/_scandir.c
@@ -54,6 +54,8 @@ path_cleanup(path_t *path) {
     if (path->cleanup) {
         Py_CLEAR(path->cleanup);
     }
+    free(path->wide);
+    free(path->narrow);
 }
 
 #ifdef MS_WINDOWS


### PR DESCRIPTION
According to the standard free(NULL) has no effect, so I decided against redundant checks. Let me know if there's another consideration I overlooked.
