### PR TITLE
Attempting import of setuptools first

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 """Run "python setup.py install" to install scandir."""
 
-from distutils.core import setup, Extension
+try:
+    from setuptools import setup, Extension
+except ImportError:
+    from distutils.core import setup, Extension
 import os
 import re
 


### PR DESCRIPTION
setup.py was not able to compile on Windows when Microsoft Visual C++ Compiler for Python 2.7 is used. It seems only a recent version of setuptools is able to find the vcvarsall.bat file for this compiler.