### PR TITLE
Change stat_result st_?time to floats

### DIFF
--- a/_scandir.c
+++ b/_scandir.c
@@ -672,9 +672,10 @@ static PyStructSequence_Field stat_result_fields[] = {
     {"st_uid",     "user ID of owner"},
     {"st_gid",     "group ID of owner"},
     {"st_size",    "total size, in bytes"},
-    {"st_atime",   "integer time of last access"},
-    {"st_mtime",   "integer time of last modification"},
-    {"st_ctime",   "integer time of last change"},
+    /* The NULL is replaced with PyStructSequence_UnnamedField later. */
+    {NULL,         "integer time of last access"},
+    {NULL,         "integer time of last modification"},
+    {NULL,         "integer time of last change"},
     {"st_atime",   "time of last access"},
     {"st_mtime",   "time of last modification"},
     {"st_ctime",   "time of last change"},
@@ -1803,6 +1804,9 @@ init_scandir(void)
     if (!billion)
         INIT_ERROR;
 
+    stat_result_desc.fields[7].name = PyStructSequence_UnnamedField;
+    stat_result_desc.fields[8].name = PyStructSequence_UnnamedField;
+    stat_result_desc.fields[9].name = PyStructSequence_UnnamedField;
     PyStructSequence_InitType(&StatResultType, &stat_result_desc);
     structseq_new = StatResultType.tp_new;
     StatResultType.tp_new = statresult_new;

--- a/test/test_scandir.py
+++ b/test/test_scandir.py
@@ -133,8 +133,8 @@ class TestMixin(object):
             os_stat = os.stat(os.path.join(TEST_PATH, entry.name))
             scandir_stat = entry.stat()
             self.assertEqual(os_stat.st_mode, scandir_stat.st_mode)
-            self.assertEqual(int(os_stat.st_mtime), int(scandir_stat.st_mtime))
-            self.assertEqual(int(os_stat.st_ctime), int(scandir_stat.st_ctime))
+            self.assertEqual(os_stat.st_mtime, scandir_stat.st_mtime)
+            self.assertEqual(os_stat.st_ctime, scandir_stat.st_ctime)
             if entry.is_file():
                 self.assertEqual(os_stat.st_size, scandir_stat.st_size)
 


### PR DESCRIPTION
Scandir entry.stat().st_?time entries  now match os.stat(). Fixes #63