### PR TITLE
Build 32-bit Windows wheels on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,10 @@
 environment:
   matrix:
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python33-x64"
       DISTUTILS_USE_SDK: "1"


### PR DESCRIPTION
Some developers still use 32-bit Python due to old Python extension modules they use. It's nice to also build 32-bit Windows wheels. We already build wheels for ancient versions (3.3, 3.4), might as well also build 32-bit ones.

P.S. This actually also gives the project CI for 32-bit Windows.