### PR TITLE
Issue 70: expose DirEntry type

### DIFF
--- a/_scandir.c
+++ b/_scandir.c
@@ -1819,6 +1819,8 @@ init_scandir(void)
     if (PyType_Ready(&DirEntryType) < 0)
         INIT_ERROR;
 
+    PyModule_AddObject(module, "DirEntry", (PyObject *)&DirEntryType);
+
 #if PY_MAJOR_VERSION >= 3
     return module;
 #endif

--- a/scandir.py
+++ b/scandir.py
@@ -386,13 +386,17 @@ if sys.platform == 'win32':
 
     if _scandir is not None:
         scandir_c = _scandir.scandir
+        DirEntry_c = _scandir.DirEntry
 
     if _scandir is not None:
         scandir = scandir_c
+        DirEntry = DirEntry_c
     elif ctypes is not None:
         scandir = scandir_python
+        DirEntry = Win32DirEntryPython
     else:
         scandir = scandir_generic
+        DirEntry = GenericDirEntry
 
 
 # Linux, OS X, and BSD implementation
@@ -564,18 +568,23 @@ elif sys.platform.startswith(('linux', 'darwin', 'sunos5')) or 'bsd' in sys.plat
 
     if _scandir is not None:
         scandir_c = _scandir.scandir
+        DirEntry_c = _scandir.DirEntry
 
     if _scandir is not None:
         scandir = scandir_c
+        DirEntry = DirEntry_c
     elif ctypes is not None:
         scandir = scandir_python
+        DirEntry = PosixDirEntry
     else:
         scandir = scandir_generic
+        DirEntry = GenericDirEntry
 
 
 # Some other system -- no d_type or stat information
 else:
     scandir = scandir_generic
+    DirEntry = GenericDirEntry
 
 
 def _walk(top, topdown=True, onerror=None, followlinks=False):

--- a/test/test_scandir.py
+++ b/test/test_scandir.py
@@ -297,6 +297,17 @@ if has_scandir:
                 TestMixin.setUp(self)
 
 
+    class TestScandirDirEntry(unittest.TestCase):
+        def setUp(self):
+            if not os.path.exists(TEST_PATH):
+                setup_main()
+
+        def test_iter_returns_dir_entry(self):
+            it = scandir.scandir(TEST_PATH)
+            entry = next(it)
+            assert isinstance(entry, scandir.DirEntry)
+
+
 if hasattr(os, 'scandir'):
     class TestScandirOS(TestMixin, unittest.TestCase):
         def setUp(self):


### PR DESCRIPTION
Address #70 and match a patch to the latest version of `scandir` in the python 3.6 standard library by exposing the DirEntry type returned by whatever implementation of `scandir` is used on that system as `scandir.DirEntry`.