### PR TITLE
Use unittest2 for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -3,7 +3,11 @@
 import glob
 import os
 import sys
-import unittest
+
+if sys.version_info[:2] < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 def main():

--- a/test/test_scandir.py
+++ b/test/test_scandir.py
@@ -6,7 +6,11 @@ import os
 import shutil
 import sys
 import time
-import unittest
+
+if sys.version_info[:2] < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 try:
     import scandir

--- a/test/test_walk.py
+++ b/test/test_walk.py
@@ -3,7 +3,11 @@
 import os
 import shutil
 import sys
-import unittest
+
+if sys.version_info[:2] < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 import scandir
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,3 +3,5 @@ envlist = py27,py36
 
 [testenv]
 commands=python test/run_tests.py
+deps =
+    py26: unittest2


### PR DESCRIPTION
Tests are failing on Python 2.6 for scandir 1.7 due to the use of the delta keyword for unittest.failUnlessAlmostEqual() in test/test_scandir.py. While the test could be reworked to avoid using delta, using unittest2 will make it easier to support future tests and avoid having to workaround the limitations of unittest in Python 2.6.

```
======================================================================
ERROR: test_stat (test_scandir.TestScandirC)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/avram/Desktop/scandir-1.7-orig/test/test_scandir.py", line 133, in test_stat
    self.assertAlmostEqual(os_stat.st_mtime, scandir_stat.st_mtime, delta=1)
TypeError: failUnlessAlmostEqual() got an unexpected keyword argument 'delta'

======================================================================
ERROR: test_stat (test_scandir.TestScandirGeneric)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/avram/Desktop/scandir-1.7-orig/test/test_scandir.py", line 133, in test_stat
    self.assertAlmostEqual(os_stat.st_mtime, scandir_stat.st_mtime, delta=1)
TypeError: failUnlessAlmostEqual() got an unexpected keyword argument 'delta'

======================================================================
ERROR: test_stat (test_scandir.TestScandirPython)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/avram/Desktop/scandir-1.7-orig/test/test_scandir.py", line 133, in test_stat
    self.assertAlmostEqual(os_stat.st_mtime, scandir_stat.st_mtime, delta=1)
TypeError: failUnlessAlmostEqual() got an unexpected keyword argument 'delta'
```