### PR TITLE
fix breakage on solaris derivates when c ext is not built

### DIFF
--- a/scandir.py
+++ b/scandir.py
@@ -586,7 +586,7 @@ elif sys.platform.startswith(('linux', 'darwin', 'sunos5')) or 'bsd' in sys.plat
     if _scandir is not None:
         scandir = scandir_c
         DirEntry = DirEntry_c
-    elif ctypes is not None:
+    elif ctypes is not None and have_dirent_d_type:
         scandir = scandir_python
         DirEntry = PosixDirEntry
     else:


### PR DESCRIPTION
the fixed if-condition was inconsistent with a similar one some lines above.

this lead to the following traceback IF the _scandir c ext was not available:

```
>>> from scandir import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../lib/python3.4/site-packages/scandir.py", line 591, in <module>
    DirEntry = PosixDirEntry
NameError: name 'PosixDirEntry' is not defined
```

note: this fixed the traceback, but it will use the slow generic implementation now on solaris and derivates.

there is still a regression in 1.9.0 to fix: why is the C extension not built any more when the package is installed from pypi? It worked in 1.8.0.

see #110 for more details. @ronny any idea why the c ext building does not happen?