### PR TITLE
drop dead pythons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.so
 *.sublime-project
 *.sublime-workspace
+.idea
 benchtree
 build
 dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ was `accepted <https://mail.python.org/pipermail/python-dev/2014-July/135561.htm
 in July 2014 by Victor Stinner, the BDFL-delegate for the PEP.
 
 This ``scandir`` module is intended to work on Python 2.7+ and Python
-3.2+ (and it has been tested on those versions).
+3.4+ (and it has been tested on those versions).
 
 
 Background

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ PEP that proposes including ``scandir`` in the Python standard library,
 was `accepted <https://mail.python.org/pipermail/python-dev/2014-July/135561.html>`_
 in July 2014 by Victor Stinner, the BDFL-delegate for the PEP.
 
-This ``scandir`` module is intended to work on Python 2.6+ and Python
+This ``scandir`` module is intended to work on Python 2.7+ and Python
 3.2+ (and it has been tested on those versions).
 
 
@@ -94,7 +94,6 @@ Windows 7 64-bit SSD   2.7.7 64-bit     10.3
 Windows 7 64-bit NFS   2.7.6 64-bit     36.8
 Windows 7 64-bit SSD   3.4.1 64-bit     9.9
 Windows 7 64-bit SSD   3.5.0 64-bit     9.5
-CentOS 6.2 64-bit      2.6.6 64-bit     3.9
 Ubuntu 14.04 64-bit    2.7.6 64-bit     5.8
 Mac OS X 10.9.3        2.7.5 64-bit     3.8
 ====================   ==============   =============

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
         'Topic :: System :: Operating System',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -3,11 +3,7 @@
 import glob
 import os
 import sys
-
-if sys.version_info[:2] < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 
 def main():

--- a/test/test_scandir.py
+++ b/test/test_scandir.py
@@ -73,8 +73,7 @@ def setup_symlinks():
 
     dir_name = os.path.abspath(join(TEST_PATH, 'linkdir', 'linksubdir'))
     dir_link = join(TEST_PATH, 'linkdir', 'link_to_dir')
-    if sys.version_info >= (3, 3):
-        # "target_is_directory" was only added in Python 3.3
+    if IS_PY3:
         os.symlink(dir_name, dir_link, target_is_directory=True)
     else:
         os.symlink(dir_name, dir_link)

--- a/test/test_scandir.py
+++ b/test/test_scandir.py
@@ -6,11 +6,7 @@ import os
 import shutil
 import sys
 import time
-
-if sys.version_info[:2] < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 try:
     import scandir
@@ -151,8 +147,7 @@ class TestMixin(object):
 
     def test_file_attributes(self):
         if sys.platform != 'win32' or not self.has_file_attributes:
-            # st_file_attributes is Win32 specific (but can't use
-            # unittest.skipUnless on Python 2.6)
+            # st_file_attributes is Win32 specific
             return self.skipTest('st_file_attributes not supported')
 
         entries = dict((e.name, e) for e in self.scandir_func(TEST_PATH))

--- a/test/test_walk.py
+++ b/test/test_walk.py
@@ -9,6 +9,8 @@ import scandir
 
 walk_func = scandir.walk
 
+IS_PY3 = sys.version_info >= (3, 0)
+
 
 class TestWalk(unittest.TestCase):
     testfn = os.path.join(os.path.dirname(__file__), 'temp')
@@ -48,8 +50,7 @@ class TestWalk(unittest.TestCase):
         has_symlink = hasattr(os, "symlink")
         if has_symlink:
             try:
-                if sys.platform == 'win32' and sys.version_info >= (3, 2):
-                    # "target_is_directory" was only added in Python 3.2 (on Windows)
+                if IS_PY3:
                     os.symlink(os.path.abspath(t2_path), link_path, target_is_directory=True)
                 else:
                     os.symlink(os.path.abspath(t2_path), link_path)
@@ -176,8 +177,7 @@ class TestWalkSymlink(unittest.TestCase):
 
         link_name = os.path.join(self.temp_dir, 'link_to_dir')
         try:
-            if sys.platform == 'win32' and sys.version_info >= (3, 2):
-                # "target_is_directory" was only added in Python 3.2 (on Windows)
+            if IS_PY3:
                 os.symlink(self.dir_name, link_name, target_is_directory=True)
             else:
                 os.symlink(self.dir_name, link_name)

--- a/test/test_walk.py
+++ b/test/test_walk.py
@@ -3,11 +3,7 @@
 import os
 import shutil
 import sys
-
-if sys.version_info[:2] < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 import scandir
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,3 @@ envlist = py27,py36
 
 [testenv]
 commands=python test/run_tests.py
-deps =
-    py26: unittest2


### PR DESCRIPTION
related to #113.

notes:
- 2.6: dead since long, everybody should be at least on 2.7 nowadays (2.7 going out of support soon also)
- <3.4: dead since long, everybody should be at least on 3.4 nowadays (3.4 going out of support soon also)
- py3 < 3.4 was not automatically tested any more and no support for it was announced in pypi metadata before this pull request. only the readme talked about 3.2+ and the code had some support in place.
- i suggest increasing the major version number (to 2) when releasing this (assuming you do semantic versioning).
