### PR TITLE
more work on travis-ci testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,14 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=py37
+        - language: generic
+          os: osx
+          osx_image: xcode9.4
+          env: TOXENV=py27,py36
+        - language: generic
+          os: osx
+          osx_image: xcode10.1
+          env: TOXENV=py27,py37
 
 install: pip install tox
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ matrix:
           dist: xenial
           env: TOXENV=py37
 
-install: pip install tox-travis
+install: pip install tox
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py27,py36
+envlist = py{27,34,35,36,37},pypy
+skip_missing_interpreters=true
 
 [testenv]
 commands=python test/run_tests.py


### PR DESCRIPTION
tox-travis: removed.

macOS: I took the easy approach here and just used the pythons I found already being installed on some xcode versions.

We do more effort for borgbackup, so if we want more for scandir also, all the scripting could be taken from there. But sometimes brew causes issues and building pythons via pyenv is rather slow, so not sure if we want that here also.