### PR TITLE
Redefine _Py_stat_struct if Python 3.11 or later

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,10 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['2.7', 'pypy-2.7', '3.9', '3.10']
+        python-version: ['2.7', 'pypy-2.7', '3.9', '3.10', '3.11']
         exclude:
           - os: macos-latest
             python-version: 'pypy-2.7'

--- a/_scandir.c
+++ b/_scandir.c
@@ -94,7 +94,7 @@ comment):
 
 // _Py_stat_struct is already defined in fileutils.h on Python 3.5+
 // But not in PyPy
-#if PY_MAJOR_VERSION < 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 5) || defined(PYPY_VERSION_NUM)
+#if PY_MAJOR_VERSION < 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 5) || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 11) || defined(PYPY_VERSION_NUM)
 #ifdef MS_WINDOWS
 struct _Py_stat_struct {
     unsigned long st_dev;


### PR DESCRIPTION
To address https://github.com/benhoyt/scandir/issues/141 .

I considered some approaches, but I can see that MS_WINDOWS's _Py_stat_struct definition can be seen from python source code, not 3rdparty modules, so maybe redefining is better.