### PR TITLE
fix test build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['2.7', 'pypy-2.7', '3.9', '3.10', '3.11']
+        python-version: ['pypy-2.7', '3.9', '3.10', '3.11']
         exclude:
           - os: macos-latest
             python-version: 'pypy-2.7'
-        exclude:
           - os: windows-latest
             python-version: 'pypy-2.7'
     steps:
@@ -26,6 +25,28 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Show Python Version
+        run: |
+          python --version
+      - name: Install dependencies
+        run: |
+          python -m pip install wheel
+      - name: Install
+        run: |
+          python -m pip -v install --global-option=--require-scandir-extension .
+      - name: Run tests
+        run: |
+          python test/run_tests.py
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    container:
+      image: python:2.7.18-buster
+    steps:
+      - uses: actions/checkout@v2
       - name: Show Python Version
         run: |
           python --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
           python -m pip install wheel
       - name: Install
         run: |
-          python -m pip install .
+          python -m pip -v install --global-option=--require-scandir-extension .
       - name: Run tests
         run: |
           python test/run_tests.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Show Python Version
-        run: |
-          python --version
       - name: Install dependencies
         run: |
           python -m pip install wheel
@@ -39,15 +36,10 @@ jobs:
           python test/run_tests.py
   build27:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     container:
       image: python:2.7.18-buster
     steps:
       - uses: actions/checkout@v2
-      - name: Show Python Version
-        run: |
-          python --version
       - name: Install dependencies
         run: |
           python -m pip install wheel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,7 @@ jobs:
       - name: Run tests
         run: |
           python test/run_tests.py
-
-jobs:
-  build:
+  build27:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,15 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Run tests
+      - name: Show Python Version
         run: |
           python --version
-          python setup.py install
+      - name: Install dependencies
+        run: |
+          python -m pip install wheel
+      - name: Install
+        run: |
+          python -m pip install .
+      - name: Run tests
+        run: |
           python test/run_tests.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,9 @@ jobs:
         run: |
           python -m pip install wheel
       - name: Install
+        shell: bash
         run: |
-          python -m pip -v install --global-option=--require-scandir-extension .
+          SCANDIR_REQUIRE_C_EXTENSION=1 python -m pip -v install .
       - name: Run tests
         run: |
           python test/run_tests.py
@@ -45,7 +46,7 @@ jobs:
           python -m pip install wheel
       - name: Install
         run: |
-          python -m pip -v install --global-option=--require-scandir-extension .
+          SCANDIR_REQUIRE_C_EXTENSION=1 python -m pip -v install .
       - name: Run tests
         run: |
           python test/run_tests.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,9 @@ jobs:
         exclude:
           - os: macos-latest
             python-version: 'pypy-2.7'
+        exclude:
+          - os: windows-latest
+            python-version: 'pypy-2.7'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,7 @@ import re
 import sys
 import logging
 
-if '--require-scandir-extension' in sys.argv:
-    sys.argv = [arg for arg in sys.argv if arg != '--require-scandir-extension']
-    require_c_extension = True
-else:
-    require_c_extension = False
+require_c_extension = bool(os.environ.get('SCANDIR_REQUIRE_C_EXTENSION'))
 
 # Get version without importing scandir because that will lock the
 # .pyd file (if scandir is already installed) so it can't be
@@ -49,7 +45,7 @@ class BuildExt(base_build_ext):
             base_build_ext.build_extension(self, ext)
         except Exception:
             if require_c_extension:
-                logging.error('--require-scandir-extension is set, not falling back to Python implementation')
+                logging.error('SCANDIR_REQUIRE_C_EXTENSION is set, not falling back to Python implementation')
                 raise
             info = sys.exc_info()
             logging.warn("building %s failed with %s: %s", ext.name, info[0], info[1])

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ import logging
 
 if '--require-scandir-extension' in sys.argv:
     sys.argv = [arg for arg in sys.argv if arg != '--require-scandir-extension']
-    require_scandir_extension = True
+    require_c_extension = True
 else:
-    require_scandir_extension = False
+    require_c_extension = False
 
 # Get version without importing scandir because that will lock the
 # .pyd file (if scandir is already installed) so it can't be
@@ -48,13 +48,13 @@ class BuildExt(base_build_ext):
         try:
             base_build_ext.build_extension(self, ext)
         except Exception:
-            if require_scandir_extension:
+            if require_c_extension:
                 logging.error('--require-scandir-extension is set, not falling back to Python implementation')
                 raise
             info = sys.exc_info()
             logging.warn("building %s failed with %s: %s", ext.name, info[0], info[1])
 
-extension = Extension('_scandir', ['_scandir.c'], optional=not require_scandir_extension)
+extension = Extension('_scandir', ['_scandir.c'], optional=not require_c_extension)
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,12 @@ import re
 import sys
 import logging
 
+if '--require-scandir-extension' in sys.argv:
+    sys.argv = [arg for arg in sys.argv if arg != '--require-scandir-extension']
+    require_scandir_extension = True
+else:
+    require_scandir_extension = False
+
 # Get version without importing scandir because that will lock the
 # .pyd file (if scandir is already installed) so it can't be
 # overwritten during the install process
@@ -42,10 +48,13 @@ class BuildExt(base_build_ext):
         try:
             base_build_ext.build_extension(self, ext)
         except Exception:
+            if require_scandir_extension:
+                logging.error('--require-scandir-extension is set, not falling back to Python implementation')
+                raise
             info = sys.exc_info()
             logging.warn("building %s failed with %s: %s", ext.name, info[0], info[1])
 
-extension = Extension('_scandir', ['_scandir.c'], optional=True)
+extension = Extension('_scandir', ['_scandir.c'], optional=not require_scandir_extension)
 
 
 setup(


### PR DESCRIPTION
- 4d9d52d4619e837cf1ddd84e8f107236d44c5a63 fixes macos, though 2.7 cannot be fixed due to package removal
- Now c55be8114fa7c82cfc1ee35901be1e0668edbfc3 enforces extension. https://github.com/benhoyt/scandir/actions/runs/5993519451/job/16254028573 had build failure but we did not notice without enforcing extension.
- Also 2.7 test has been recovered by using containers.